### PR TITLE
Improve benchmark configurability

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: '5.6.4'
     hooks:
       - id: isort
+        args: ["--profile", "black"]
   - repo: https://github.com/asottile/pyupgrade
     rev: 'v2.25.0'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: '5.9.1'
+    rev: '5.6.4'
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade

--- a/API/bench_dataframe.py
+++ b/API/bench_dataframe.py
@@ -13,7 +13,7 @@ def bench_construction(benchmark, N):
 
 @cudf_benchmark(cls="dataframe", dtype="float", cols=6)
 @pytest.mark.parametrize(
-    "expr", ["a+b", "a+b+c+d+e", "a / (sin(a) + cos(b)) * tan(d*e*f)"]
+    "expr", ["a+b", "a+b+c+d+e", "a / (sin(a) + cos(b)) * tanh(d*e*f)"]
 )
 def bench_eval_func(benchmark, expr, dataframe):
     benchmark(dataframe.eval, expr)

--- a/API/bench_frame_or_index.py
+++ b/API/bench_frame_or_index.py
@@ -16,6 +16,7 @@ def bench_take(benchmark, gather_how, fraction, frame_or_index):
     benchmark(frame_or_index.take, gather_map)
 
 
+@pytest.mark.pandas_incompatible  # Series/Index work, but not DataFrame
 @cudf_benchmark(cls="frame_or_index", dtype="int")
 def bench_argsort(benchmark, frame_or_index):
     benchmark(frame_or_index.argsort)
@@ -33,6 +34,7 @@ def bench_where(benchmark, frame_or_index):
 
 
 @cudf_benchmark(cls="frame_or_index", dtype="int", nulls=False)
+@pytest.mark.pandas_incompatible
 def bench_values_host(benchmark, frame_or_index):
     benchmark(lambda: frame_or_index.values_host)
 
@@ -53,11 +55,13 @@ def bench_to_numpy(benchmark, frame_or_index):
 
 
 @cudf_benchmark(cls="frame_or_index", dtype="int", nulls=False)
+@pytest.mark.pandas_incompatible
 def bench_to_cupy(benchmark, frame_or_index):
     benchmark(frame_or_index.to_cupy)
 
 
 @cudf_benchmark(cls="frame_or_index", dtype="int")
+@pytest.mark.pandas_incompatible
 def bench_to_arrow(benchmark, frame_or_index):
     benchmark(frame_or_index.to_arrow)
 
@@ -67,7 +71,7 @@ def bench_astype(benchmark, frame_or_index):
     benchmark(frame_or_index.astype, float)
 
 
-@pytest.mark.parametrize("ufunc", [np.add, np.logical_and, np.bitwise_and])
+@pytest.mark.parametrize("ufunc", [np.add, np.logical_and])
 @cudf_benchmark(cls="frame_or_index", dtype="int")
 def bench_ufunc_series_binary(benchmark, frame_or_index, ufunc):
     benchmark(ufunc, frame_or_index, frame_or_index)
@@ -75,9 +79,8 @@ def bench_ufunc_series_binary(benchmark, frame_or_index, ufunc):
 
 @pytest.mark.parametrize(
     "op",
-    [operator.add, operator.mul, operator.__and__, operator.eq],
+    [operator.add, operator.mul, operator.eq],
 )
 @cudf_benchmark(cls="frame_or_index", dtype="int")
 def bench_binops(benchmark, op, frame_or_index):
-    # Use integer data so that __and__ is well-defined.
     benchmark(lambda: op(frame_or_index, frame_or_index))

--- a/API/bench_multiindex.py
+++ b/API/bench_multiindex.py
@@ -14,19 +14,24 @@ def pidx():
 
 @pytest.fixture
 def midx(pidx):
-    return cudf.MultiIndex.from_pandas(pidx)
+    num_elements = int(1e3)
+    a = np.random.randint(0, num_elements // 10, num_elements)
+    b = np.random.randint(0, num_elements // 10, num_elements)
+    df = cudf.DataFrame({"a": a, "b": b})
+    return cudf.MultiIndex.from_frame(df)
 
 
+@pytest.mark.pandas_incompatible
 def bench_from_pandas(benchmark, pidx):
     benchmark(cudf.MultiIndex.from_pandas, pidx)
 
 
-def bench_constructor(benchmark, pidx):
-    benchmark(cudf.MultiIndex, codes=pidx.codes, levels=pidx.levels, names=pidx.names)
+def bench_constructor(benchmark, midx):
+    benchmark(cudf.MultiIndex, codes=midx.codes, levels=midx.levels, names=midx.names)
 
 
-def bench_from_frame(benchmark, pidx):
-    benchmark(cudf.MultiIndex.from_frame, pidx.to_frame(index=False))
+def bench_from_frame(benchmark, midx):
+    benchmark(cudf.MultiIndex.from_frame, midx.to_frame(index=False))
 
 
 def bench_copy(benchmark, midx):

--- a/common/config.py
+++ b/common/config.py
@@ -1,23 +1,64 @@
 """Module used for global configuration of benchmarks.
 
-All common modules (cudf, cupy) should be imported from here by benchmark
-modules to allow configuration if needed.
+This file contains global definitions that are important for configuring all
+benchmarks such as fixture sizes. In addition, this file supports the following
+features:
+    - Defining the CUDF_BENCHMARKS_USE_PANDAS environment variable will change
+      all benchmarks to run with pandas instead of cudf (and numpy instead of
+      cupy). This feature enables easy comparisons of benchmarks between cudf
+      and pandas. All common modules (cudf, cupy) should be imported from here
+      by benchmark modules to allow configuration if needed.
+    - Defining CUDF_BENCHMARKS_TEST_ONLY will set global configuration
+      variables to avoid running large benchmarks, instead using minimal values
+      to simply ensure that benchmarks are functional.
 """
 import os
+import sys
 
 # Environment variable-based configuration of benchmarking pandas or cudf.
 if "CUDF_BENCHMARKS_USE_PANDAS" in os.environ:
     import numpy as cupy
     import pandas as cudf
+
+    # cudf internals offer no pandas compatibility guarantees, and we also
+    # never need to compare those benchmarks to pandas.
+    collect_ignore = ["internal/"]
+
+    # Also filter out benchmarks of APIs that are not compatible with pandas.
+    def is_pandas_compatible(item):
+        return all(m.name != "pandas_incompatible" for m in item.own_markers)
+
+    def pytest_collection_modifyitems(session, config, items):
+        items[:] = list(filter(is_pandas_compatible, items))
+
 else:
     import cudf  # noqa: W0611, F401
     import cupy
 
+    collect_ignore = []
 
-# TODO: Choose real values here before merging.
+    def pytest_collection_modifyitems(session, config, items):
+        pass
+
+
+def pytest_sessionstart(session):
+    """Add the common files to the path for all tests to import."""
+    sys.path.insert(0, os.path.join(os.getcwd(), "common"))
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Clean up sys.path after exit."""
+    if "common" in sys.path[0]:
+        del sys.path[0]
+
+
 # Constants used to define benchmarking standards.
-NUM_ROWS = [10, 20]  # The column lengths to use for benchmarked objects
-NUM_COLS = [1, 6]  # The numbers of columns to use for benchmarked DataFrames
+if "CUDF_BENCHMARKS_TEST_ONLY" in os.environ:
+    NUM_ROWS = [10, 20]
+    NUM_COLS = [1, 6]
+else:
+    NUM_ROWS = [100, 10_000, 1_000_000]
+    NUM_COLS = [1, 6]
 
 # A dictionary of callables that create a column of a specified length
 random_state = cupy.random.RandomState(42)

--- a/common/utils.py
+++ b/common/utils.py
@@ -21,13 +21,13 @@ def make_gather_map(len_gather_map: Real, len_column: Real, how: str):
 
     rstate = cp.random.RandomState(seed=0)
     if how == "sequence":
-        return cudf.Series(cp.arange(0, len_gather_map))._column
+        return cudf.Series(cp.arange(0, len_gather_map))
     elif how == "reverse":
         return cudf.Series(
             cp.arange(len_column - 1, len_column - len_gather_map - 1, -1)
-        )._column
+        )
     elif how == "random":
-        return cudf.Series(rstate.randint(0, len_column, len_gather_map))._column
+        return cudf.Series(rstate.randint(0, len_column, len_gather_map))
 
 
 def make_boolean_mask_column(size):

--- a/conftest.py
+++ b/conftest.py
@@ -58,18 +58,16 @@ import pytest_cases
 # into the main repo.
 sys.path.insert(0, os.path.join(os.getcwd(), "common"))
 
-from config import NUM_COLS, NUM_ROWS, column_generators, cudf  # noqa: E402
-
-
-def pytest_sessionstart(session):
-    """Add the common files to the path for all tests to import."""
-    sys.path.insert(0, os.path.join(os.getcwd(), "common"))
-
-
-def pytest_sessionfinish(session, exitstatus):
-    """Clean up sys.path after exit."""
-    if "common" in sys.path[0]:
-        del sys.path[0]
+from config import NUM_ROWS  # noqa: W0611, E402, F401
+from config import column_generators  # noqa: F401
+from config import cudf  # noqa: E402
+from config import (
+    NUM_COLS,
+    collect_ignore,
+    pytest_collection_modifyitems,
+    pytest_sessionfinish,
+    pytest_sessionstart,
+)
 
 
 @pytest_cases.fixture(params=[0, 1], ids=["AxisIndex", "AxisColumn"])

--- a/conftest.py
+++ b/conftest.py
@@ -58,16 +58,22 @@ import pytest_cases
 # into the main repo.
 sys.path.insert(0, os.path.join(os.getcwd(), "common"))
 
-from config import NUM_ROWS  # noqa: W0611, E402, F401
-from config import column_generators  # noqa: F401
-from config import cudf  # noqa: E402
-from config import (
+from config import cudf  # noqa: W0611, E402, F401
+
+# Turn off isort until we upgrade to 5.8.0
+# https://github.com/pycqa/isort/issues/1594
+# isort: off
+from config import (  # noqa: W0611, E402, F401
     NUM_COLS,
+    NUM_ROWS,
     collect_ignore,
+    column_generators,
     pytest_collection_modifyitems,
     pytest_sessionfinish,
     pytest_sessionstart,
 )
+
+# isort: on
 
 
 @pytest_cases.fixture(params=[0, 1], ids=["AxisIndex", "AxisColumn"])

--- a/internal/bench_column_take.py
+++ b/internal/bench_column_take.py
@@ -5,5 +5,5 @@ from utils import make_gather_map
 @pytest.mark.parametrize("nullify", [True, False])
 @pytest.mark.parametrize("gather_how", ["sequence", "reverse", "random"])
 def bench_gather_single_column(benchmark, col, gather_how, nullify):
-    gather_map = make_gather_map(col.size * 0.4, col.size, gather_how)
+    gather_map = make_gather_map(col.size * 0.4, col.size, gather_how)._column
     benchmark(col.take, gather_map, nullify=nullify)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 python_files = bench_*.py
 python_classes = Bench
 python_functions = bench_*
+markers =
+    pandas_incompatible: mark a benchmark that cannot be run with pandas


### PR DESCRIPTION
This PR adds support for `CUDF_BENCHMARKS_TEST_ONLY`, which allows benchmarks to be run with small data sizes to verify that they work, for instance in CI where we don't want to incur the cost of running benchmarks with normal data sizes. This PR also improves pandas compatibility of benchmarks, fixing all benchmarks that should be compatible and excluding those that should not be. The `internal` benchmarks are all excluded, as are a number of public cudf APIs that do not have exact pandas equivalents (e.g. `to_cupy`).