### PR TITLE
Use cases for parametrization

### DIFF
--- a/API/bench_functions.py
+++ b/API/bench_functions.py
@@ -1,113 +1,12 @@
 """Benchmarks of free functions that accept cudf objects."""
 
 import pytest
+import pytest_cases
 from config import cudf, cupy
 
 
 # TODO: These cases should be migrated to properly use pytest_cases.
-@pytest.mark.parametrize(
-    "objs",
-    [
-        [
-            cudf.DataFrame({"a": [1, 2, 3] * 1000000}),
-            cudf.DataFrame({"b": [4, 5, 7] * 1000000}),
-        ],
-        [
-            cudf.DataFrame({"a": [1, 2, 3] * 1000000}),
-            cudf.DataFrame(
-                {"b": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-            ),
-        ],
-        [
-            cudf.DataFrame({"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000}),
-            cudf.DataFrame(
-                {"c": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-            ),
-        ],
-        [
-            cudf.DataFrame(
-                {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"c": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-            ),
-        ],
-        [
-            cudf.DataFrame(
-                {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"c": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
-            ),
-        ],
-        [
-            cudf.DataFrame(
-                {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"c": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"d": [1, 2, 3] * 1000000, "e": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"f": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"g": [1, 2, 3] * 1000000, "h": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-            ),
-            cudf.DataFrame(
-                {"i": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
-            ),
-        ],
-        [
-            cudf.DataFrame({"a": [1, 2, 3] * 50000}),
-            cudf.DataFrame({"b": [4, 5, 7] * 50000}),
-            cudf.DataFrame({"c": [1, 2, 3] * 50000}),
-            cudf.DataFrame({"d": [4, 5, 7] * 50000}),
-            cudf.DataFrame({"e": [1, 2, 3] * 50000}),
-            cudf.DataFrame({"f": [4, 5, 7] * 50000}),
-            cudf.DataFrame({"g": [1, 2, 3] * 50000}),
-            cudf.DataFrame({"h": [4, 5, 7] * 50000}),
-            cudf.DataFrame({"i": [1, 2, 3] * 50000}),
-            cudf.DataFrame({"j": [4, 5, 7] * 50000}),
-        ],
-        [
-            cudf.DataFrame({"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000}),
-            cudf.DataFrame(
-                {"c": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-            ),
-            cudf.DataFrame({"d": [1, 2, 3] * 1000000, "e": [4, 5, 7] * 1000000}),
-            cudf.DataFrame(
-                {"f": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-            ),
-            cudf.DataFrame({"g": [1, 2, 3] * 1000000, "h": [4, 5, 7] * 1000000}),
-            cudf.DataFrame(
-                {"i": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-            ),
-            cudf.DataFrame({"j": [1, 2, 3] * 1000000, "k": [4, 5, 7] * 1000000}),
-            cudf.DataFrame(
-                {"l": [4, 5, 7] * 1000000},
-                index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-            ),
-        ],
-    ],
-)
+@pytest_cases.parametrize_with_cases("objs", prefix="concat")
 @pytest.mark.parametrize(
     "axis",
     [

--- a/API/bench_functions.py
+++ b/API/bench_functions.py
@@ -5,7 +5,6 @@ import pytest_cases
 from config import cudf, cupy
 
 
-# TODO: These cases should be migrated to properly use pytest_cases.
 @pytest_cases.parametrize_with_cases("objs", prefix="concat")
 @pytest.mark.parametrize(
     "axis",

--- a/API/bench_functions_cases.py
+++ b/API/bench_functions_cases.py
@@ -3,7 +3,7 @@ from config import NUM_ROWS, cudf, cupy
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_1(nr):
+def concat_case_default_index(nr):
     return [
         cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr)}),
         cudf.DataFrame({"b": cupy.tile([4, 5, 7], nr)}),
@@ -11,7 +11,7 @@ def concat_case_1(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_2(nr):
+def concat_case_contiguous_indexes(nr):
     return [
         cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr)}),
         cudf.DataFrame(
@@ -22,7 +22,7 @@ def concat_case_2(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_3(nr):
+def concat_case_contiguous_indexes_different_cols(nr):
     return [
         cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(
@@ -33,7 +33,7 @@ def concat_case_3(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_4(nr):
+def concat_case_string_index(nr):
     return [
         cudf.DataFrame(
             {"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)},
@@ -47,7 +47,7 @@ def concat_case_4(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_5(nr):
+def concat_case_contiguous_string_index_different_col(nr):
     return [
         cudf.DataFrame(
             {"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)},
@@ -61,7 +61,7 @@ def concat_case_5(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_6(nr):
+def concat_case_complex_string_index(nr):
     return [
         cudf.DataFrame(
             {"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)},
@@ -91,7 +91,7 @@ def concat_case_6(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_7(nr):
+def concat_case_unique_columns(nr):
     # To avoid any edge case bugs, always use at least 10 rows per DataFrame.
     nr_actual = max(10, nr // 20)
     return [
@@ -109,7 +109,7 @@ def concat_case_7(nr):
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
-def concat_case_8(nr):
+def concat_case_unique_columns_with_different_range_index(nr):
     return [
         cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(

--- a/API/bench_functions_cases.py
+++ b/API/bench_functions_cases.py
@@ -1,0 +1,123 @@
+from config import cudf
+
+
+def concat_case_1():
+    return [
+        cudf.DataFrame({"a": [1, 2, 3] * 1000000}),
+        cudf.DataFrame({"b": [4, 5, 7] * 1000000}),
+    ]
+
+
+def concat_case_2():
+    return [
+        cudf.DataFrame({"a": [1, 2, 3] * 1000000}),
+        cudf.DataFrame(
+            {"b": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+        ),
+    ]
+
+
+def concat_case_3():
+    return [
+        cudf.DataFrame({"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000}),
+        cudf.DataFrame(
+            {"c": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+        ),
+    ]
+
+
+def concat_case_4():
+    return [
+        cudf.DataFrame(
+            {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"c": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+        ),
+    ]
+
+
+def concat_case_5():
+    return [
+        cudf.DataFrame(
+            {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"c": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
+        ),
+    ]
+
+
+def concat_case_6():
+    return [
+        cudf.DataFrame(
+            {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"c": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"d": [1, 2, 3] * 1000000, "e": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"f": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"g": [1, 2, 3] * 1000000, "h": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"i": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
+        ),
+    ]
+
+
+def concat_case_7():
+    return [
+        cudf.DataFrame({"a": [1, 2, 3] * 50000}),
+        cudf.DataFrame({"b": [4, 5, 7] * 50000}),
+        cudf.DataFrame({"c": [1, 2, 3] * 50000}),
+        cudf.DataFrame({"d": [4, 5, 7] * 50000}),
+        cudf.DataFrame({"e": [1, 2, 3] * 50000}),
+        cudf.DataFrame({"f": [4, 5, 7] * 50000}),
+        cudf.DataFrame({"g": [1, 2, 3] * 50000}),
+        cudf.DataFrame({"h": [4, 5, 7] * 50000}),
+        cudf.DataFrame({"i": [1, 2, 3] * 50000}),
+        cudf.DataFrame({"j": [4, 5, 7] * 50000}),
+    ]
+
+
+def concat_case_8():
+    return [
+        cudf.DataFrame({"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000}),
+        cudf.DataFrame(
+            {"c": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+        ),
+        cudf.DataFrame({"d": [1, 2, 3] * 1000000, "e": [4, 5, 7] * 1000000}),
+        cudf.DataFrame(
+            {"f": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+        ),
+        cudf.DataFrame({"g": [1, 2, 3] * 1000000, "h": [4, 5, 7] * 1000000}),
+        cudf.DataFrame(
+            {"i": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+        ),
+        cudf.DataFrame({"j": [1, 2, 3] * 1000000, "k": [4, 5, 7] * 1000000}),
+        cudf.DataFrame(
+            {"l": [4, 5, 7] * 1000000},
+            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+        ),
+    ]

--- a/API/bench_functions_cases.py
+++ b/API/bench_functions_cases.py
@@ -1,123 +1,134 @@
-from config import cudf
+import pytest_cases
+from config import NUM_ROWS, cudf
 
 
-def concat_case_1():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_1(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * 1000000}),
-        cudf.DataFrame({"b": [4, 5, 7] * 1000000}),
+        cudf.DataFrame({"a": [1, 2, 3] * nr}),
+        cudf.DataFrame({"b": [4, 5, 7] * nr}),
     ]
 
 
-def concat_case_2():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_2(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * 1000000}),
+        cudf.DataFrame({"a": [1, 2, 3] * nr}),
         cudf.DataFrame(
-            {"b": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
-        ),
-    ]
-
-
-def concat_case_3():
-    return [
-        cudf.DataFrame({"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000}),
-        cudf.DataFrame(
-            {"c": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+            {"b": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
     ]
 
 
-def concat_case_4():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_3(nr):
     return [
+        cudf.DataFrame({"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr}),
         cudf.DataFrame(
-            {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-        ),
-        cudf.DataFrame(
-            {"c": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+            {"c": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
     ]
 
 
-def concat_case_5():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_4(nr):
     return [
         cudf.DataFrame(
-            {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+            {"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
+            {"c": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
     ]
 
 
-def concat_case_6():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_5(nr):
     return [
         cudf.DataFrame(
-            {"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
+            {"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
-        ),
-        cudf.DataFrame(
-            {"d": [1, 2, 3] * 1000000, "e": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-        ),
-        cudf.DataFrame(
-            {"f": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
-        ),
-        cudf.DataFrame(
-            {"g": [1, 2, 3] * 1000000, "h": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=0, stop=3000000).astype("str"),
-        ),
-        cudf.DataFrame(
-            {"i": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=3000000, stop=6000000).astype("str"),
+            {"c": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
         ),
     ]
 
 
-def concat_case_7():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_6(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * 50000}),
-        cudf.DataFrame({"b": [4, 5, 7] * 50000}),
-        cudf.DataFrame({"c": [1, 2, 3] * 50000}),
-        cudf.DataFrame({"d": [4, 5, 7] * 50000}),
-        cudf.DataFrame({"e": [1, 2, 3] * 50000}),
-        cudf.DataFrame({"f": [4, 5, 7] * 50000}),
-        cudf.DataFrame({"g": [1, 2, 3] * 50000}),
-        cudf.DataFrame({"h": [4, 5, 7] * 50000}),
-        cudf.DataFrame({"i": [1, 2, 3] * 50000}),
-        cudf.DataFrame({"j": [4, 5, 7] * 50000}),
+        cudf.DataFrame(
+            {"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"c": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"d": [1, 2, 3] * nr, "e": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"f": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"g": [1, 2, 3] * nr, "h": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
+        ),
+        cudf.DataFrame(
+            {"i": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
+        ),
     ]
 
 
-def concat_case_8():
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_7(nr):
+    # To avoid any edge case bugs, always use at least 10 rows per DataFrame.
+    nr_actual = max(10, nr // 20)
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * 1000000, "b": [4, 5, 7] * 1000000}),
+        cudf.DataFrame({"a": [1, 2, 3] * nr_actual}),
+        cudf.DataFrame({"b": [4, 5, 7] * nr_actual}),
+        cudf.DataFrame({"c": [1, 2, 3] * nr_actual}),
+        cudf.DataFrame({"d": [4, 5, 7] * nr_actual}),
+        cudf.DataFrame({"e": [1, 2, 3] * nr_actual}),
+        cudf.DataFrame({"f": [4, 5, 7] * nr_actual}),
+        cudf.DataFrame({"g": [1, 2, 3] * nr_actual}),
+        cudf.DataFrame({"h": [4, 5, 7] * nr_actual}),
+        cudf.DataFrame({"i": [1, 2, 3] * nr_actual}),
+        cudf.DataFrame({"j": [4, 5, 7] * nr_actual}),
+    ]
+
+
+@pytest_cases.parametrize("nr", NUM_ROWS)
+def concat_case_8(nr):
+    return [
+        cudf.DataFrame({"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr}),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+            {"c": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
-        cudf.DataFrame({"d": [1, 2, 3] * 1000000, "e": [4, 5, 7] * 1000000}),
+        cudf.DataFrame({"d": [1, 2, 3] * nr, "e": [4, 5, 7] * nr}),
         cudf.DataFrame(
-            {"f": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+            {"f": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
-        cudf.DataFrame({"g": [1, 2, 3] * 1000000, "h": [4, 5, 7] * 1000000}),
+        cudf.DataFrame({"g": [1, 2, 3] * nr, "h": [4, 5, 7] * nr}),
         cudf.DataFrame(
-            {"i": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+            {"i": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
-        cudf.DataFrame({"j": [1, 2, 3] * 1000000, "k": [4, 5, 7] * 1000000}),
+        cudf.DataFrame({"j": [1, 2, 3] * nr, "k": [4, 5, 7] * nr}),
         cudf.DataFrame(
-            {"l": [4, 5, 7] * 1000000},
-            index=cudf.RangeIndex(start=1000000 * 3, stop=6000000),
+            {"l": [4, 5, 7] * nr},
+            index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
     ]

--- a/API/bench_functions_cases.py
+++ b/API/bench_functions_cases.py
@@ -1,21 +1,21 @@
 import pytest_cases
-from config import NUM_ROWS, cudf
+from config import NUM_ROWS, cudf, cupy
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
 def concat_case_1(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * nr}),
-        cudf.DataFrame({"b": [4, 5, 7] * nr}),
+        cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr)}),
+        cudf.DataFrame({"b": cupy.tile([4, 5, 7], nr)}),
     ]
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
 def concat_case_2(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * nr}),
+        cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr)}),
         cudf.DataFrame(
-            {"b": [4, 5, 7] * nr},
+            {"b": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
     ]
@@ -24,9 +24,9 @@ def concat_case_2(nr):
 @pytest_cases.parametrize("nr", NUM_ROWS)
 def concat_case_3(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr}),
+        cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * nr},
+            {"c": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
     ]
@@ -36,7 +36,7 @@ def concat_case_3(nr):
 def concat_case_4(nr):
     return [
         cudf.DataFrame(
-            {"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr},
+            {"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
@@ -50,11 +50,11 @@ def concat_case_4(nr):
 def concat_case_5(nr):
     return [
         cudf.DataFrame(
-            {"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr},
+            {"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * nr},
+            {"c": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
         ),
     ]
@@ -64,27 +64,27 @@ def concat_case_5(nr):
 def concat_case_6(nr):
     return [
         cudf.DataFrame(
-            {"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr},
+            {"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * nr},
+            {"c": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"d": [1, 2, 3] * nr, "e": [4, 5, 7] * nr},
+            {"d": cupy.tile([1, 2, 3], nr), "e": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"f": [4, 5, 7] * nr},
+            {"f": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"g": [1, 2, 3] * nr, "h": [4, 5, 7] * nr},
+            {"g": cupy.tile([1, 2, 3], nr), "h": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=0, stop=nr * 3).astype("str"),
         ),
         cudf.DataFrame(
-            {"i": [4, 5, 7] * nr},
+            {"i": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3).astype("str"),
         ),
     ]
@@ -95,40 +95,40 @@ def concat_case_7(nr):
     # To avoid any edge case bugs, always use at least 10 rows per DataFrame.
     nr_actual = max(10, nr // 20)
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * nr_actual}),
-        cudf.DataFrame({"b": [4, 5, 7] * nr_actual}),
-        cudf.DataFrame({"c": [1, 2, 3] * nr_actual}),
-        cudf.DataFrame({"d": [4, 5, 7] * nr_actual}),
-        cudf.DataFrame({"e": [1, 2, 3] * nr_actual}),
-        cudf.DataFrame({"f": [4, 5, 7] * nr_actual}),
-        cudf.DataFrame({"g": [1, 2, 3] * nr_actual}),
-        cudf.DataFrame({"h": [4, 5, 7] * nr_actual}),
-        cudf.DataFrame({"i": [1, 2, 3] * nr_actual}),
-        cudf.DataFrame({"j": [4, 5, 7] * nr_actual}),
+        cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr_actual)}),
+        cudf.DataFrame({"b": cupy.tile([4, 5, 7], nr_actual)}),
+        cudf.DataFrame({"c": cupy.tile([1, 2, 3], nr_actual)}),
+        cudf.DataFrame({"d": cupy.tile([4, 5, 7], nr_actual)}),
+        cudf.DataFrame({"e": cupy.tile([1, 2, 3], nr_actual)}),
+        cudf.DataFrame({"f": cupy.tile([4, 5, 7], nr_actual)}),
+        cudf.DataFrame({"g": cupy.tile([1, 2, 3], nr_actual)}),
+        cudf.DataFrame({"h": cupy.tile([4, 5, 7], nr_actual)}),
+        cudf.DataFrame({"i": cupy.tile([1, 2, 3], nr_actual)}),
+        cudf.DataFrame({"j": cupy.tile([4, 5, 7], nr_actual)}),
     ]
 
 
 @pytest_cases.parametrize("nr", NUM_ROWS)
 def concat_case_8(nr):
     return [
-        cudf.DataFrame({"a": [1, 2, 3] * nr, "b": [4, 5, 7] * nr}),
+        cudf.DataFrame({"a": cupy.tile([1, 2, 3], nr), "b": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(
-            {"c": [4, 5, 7] * nr},
+            {"c": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
-        cudf.DataFrame({"d": [1, 2, 3] * nr, "e": [4, 5, 7] * nr}),
+        cudf.DataFrame({"d": cupy.tile([1, 2, 3], nr), "e": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(
-            {"f": [4, 5, 7] * nr},
+            {"f": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
-        cudf.DataFrame({"g": [1, 2, 3] * nr, "h": [4, 5, 7] * nr}),
+        cudf.DataFrame({"g": cupy.tile([1, 2, 3], nr), "h": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(
-            {"i": [4, 5, 7] * nr},
+            {"i": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
-        cudf.DataFrame({"j": [1, 2, 3] * nr, "k": [4, 5, 7] * nr}),
+        cudf.DataFrame({"j": cupy.tile([1, 2, 3], nr), "k": cupy.tile([4, 5, 7], nr)}),
         cudf.DataFrame(
-            {"l": [4, 5, 7] * nr},
+            {"l": cupy.tile([4, 5, 7], nr)},
             index=cudf.RangeIndex(start=nr * 3, stop=nr * 2 * 3),
         ),
     ]

--- a/common/config.py
+++ b/common/config.py
@@ -55,11 +55,6 @@ def pytest_sessionfinish(session, exitstatus):
 if "CUDF_BENCHMARKS_TEST_ONLY" in os.environ:
     NUM_ROWS = [10, 20]
     NUM_COLS = [1, 6]
-
-    # Some benchmarks aren't solely reliant on fixtures for size and become too
-    # unwieldy. In the long run we may want a custom mark like
-    # `pandas_incompatible` for more granular identification of such functions.
-    collect_ignore.append("API/bench_functions.py")
 else:
     NUM_ROWS = [100, 10_000, 1_000_000]
     NUM_COLS = [1, 6]

--- a/common/config.py
+++ b/common/config.py
@@ -16,13 +16,14 @@ import os
 import sys
 
 # Environment variable-based configuration of benchmarking pandas or cudf.
+collect_ignore = []
 if "CUDF_BENCHMARKS_USE_PANDAS" in os.environ:
     import numpy as cupy
     import pandas as cudf
 
     # cudf internals offer no pandas compatibility guarantees, and we also
     # never need to compare those benchmarks to pandas.
-    collect_ignore = ["internal/"]
+    collect_ignore.append("internal/")
 
     # Also filter out benchmarks of APIs that are not compatible with pandas.
     def is_pandas_compatible(item):
@@ -34,8 +35,6 @@ if "CUDF_BENCHMARKS_USE_PANDAS" in os.environ:
 else:
     import cudf  # noqa: W0611, F401
     import cupy
-
-    collect_ignore = []
 
     def pytest_collection_modifyitems(session, config, items):
         pass
@@ -56,6 +55,11 @@ def pytest_sessionfinish(session, exitstatus):
 if "CUDF_BENCHMARKS_TEST_ONLY" in os.environ:
     NUM_ROWS = [10, 20]
     NUM_COLS = [1, 6]
+
+    # Some benchmarks aren't solely reliant on fixtures for size and become too
+    # unwieldy. In the long run we may want a custom mark like
+    # `pandas_incompatible` for more granular identification of such functions.
+    collect_ignore.append("API/bench_functions.py")
 else:
     NUM_ROWS = [100, 10_000, 1_000_000]
     NUM_COLS = [1, 6]


### PR DESCRIPTION
This PR switches the concat benchmarks to use `pytest_cases`'s core feature, `parametrize_with_cases`. The change has two major benefits:
1. Enforcing documentation of cases. Unlike the pure pytest version `pytest.mark.parametrize`, which frequently leads to extremely complex parametrizations whose purpose is soon lost, the case-based approach requires that each distinct case be given a self-documenting name and potentially additional documentation as well. Cases can be organized in many ways, including using classes, but I think the easiest option for our purposes is to use prefixes. If we ever encounter cases that are reusable between multiple tests we can add additional logic using globs or even arbitrary tags for filtering.
2. Cases are evaluated at runtime, similar to fixtures. That means that using cases prevents the materialization of large objects in GPU memory during the test collection phase of pytest, which is both helpful for fast testing and crucial for running benchmarks on potentially memory-constrained runners if benchmarks involve large datasets.